### PR TITLE
add section about `:verbose` & add section about vim.keymap

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1251,6 +1251,31 @@ globals = {
 このプラグインは[Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)を使用しています。
 デバッグアダプターに接続するには、[mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap/)や[puremourning/vimspector](https://github.com/puremourning/vimspector/)のようなDAPクライアントが必要です。
 
+### Luaマッピング/コマンド/オートコマンドのデバッグ
+
+マッピング/コマンド/オートコマンドが定義されている位置を `:verbose` コマンドで確認できます:
+
+```vim
+:verbose map m
+```
+
+```text
+n  m_          * <Cmd>echo 'example'<CR>
+        Last set from ~/.config/nvim/init.vim line 26
+```
+
+デフォルトでは、Luaのパフォーマンス上の理由でこの機能は無効です。
+Neovim起動時にverboseのレベルが0より上なら、この機能を有効にできます:
+
+```sh
+nvim -V1
+```
+
+参照:
+- [`:help 'verbose'`](https://neovim.io/doc/user/options.html#'verbose')
+- [`:help -V`](https://neovim.io/doc/user/starting.html#-V)
+- [neovim/neovim#15079](https://github.com/neovim/neovim/pull/15079)
+
 ### Luaコードのテスト
 
 - [plenary.nvim: test harness](https://github.com/nvim-lua/plenary.nvim/#plenarytest_harness)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1079,11 +1079,11 @@ vim.api.nvim_create_user_command('Test', function() end, {
 -- 候補リストをフィルタしてないので `:Test z<Tab>` と入力すると全ての補完候補を返します
 ```
 
-## autocommandを定義する
+## オートコマンドを定義する
 
 (この章は現在作成中です)
 
-Neovim 0.7.0はautocommands用のAPI関数を持っています。詳細は `:help api-autocmd` を参照してください。
+Neovim 0.7.0はオートコマンド用のAPI関数を持っています。詳細は `:help api-autocmd` を参照してください。
 
 - [Pull request #14661](https://github.com/neovim/neovim/pull/14661) (lua: autocmds take 2)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -362,7 +362,7 @@ end
 EOF
 
 inoremap <silent> <expr> <Tab>
-    \ pumvisible() ? "\<C-n>" :
+    \ pumvisible() ? "\<C-N>" :
     \ v:lua.check_back_space() ? "\<Tab>" :
     \ completion#trigger_completion()
 
@@ -543,20 +543,20 @@ vim.cmd([[%s/\Vfoo/bar/g]])
 次のようなマッピングを見たことがあるかもしれません。:
 
 ```vim
-inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <Tab> pumvisible() ? "\<C-N>" : "\<Tab>"
 ```
 
 同じことをLuaでやると大変です。次のようにやるかもしれません。:
 
 ```lua
 function _G.smart_tab()
-    return vim.fn.pumvisible() == 1 and [[\<C-n>]] or [[\<Tab>]]
+    return vim.fn.pumvisible() == 1 and [[\<C-N>]] or [[\<Tab>]]
 end
 
 vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr = true, noremap = true})
 ```
 
-マッピングに `\<Tab>` と `\<C-n>` が挿入されているのを知るためだけに...
+マッピングに `\<Tab>` と `\<C-N>` が挿入されているのを知るためだけに...
 
 キーコードをエスケープできるのは、Vim scriptの機能です。`\r`, `\42` や `\x10` のような多くのプログラミング言語に共通する通常のエスケープシーケンスとは別に、Vim scriptの `expr-quotes` (ダブルクォートで囲まれる文字列)を使用すると、人間が読める表現のVimキーコードをエスケープします。
 
@@ -587,10 +587,18 @@ local function t(str)
 end
 
 function _G.smart_tab()
-    return vim.fn.pumvisible() == 1 and t'<C-n>' or t'<Tab>'
+    return vim.fn.pumvisible() == 1 and t'<C-N>' or t'<Tab>'
 end
 
 vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr = true, noremap = true})
+```
+
+`vim.keymap.set()`では、このハックは必要ありません。`expr`が有効な場合、デフォルトで自動的に変換されます。:
+
+```lua
+vim.keymap.set('i', '<Tab>', function()
+    return vim.fn.pumvisible() == 1 and '<C-N>' or '<Tab>'
+end, {expr = true})
 ```
 
 参照:
@@ -888,6 +896,8 @@ end
 
 ## マッピングを定義する
 
+### API関数
+
 Neovimはマッピングを設定、取得、削除するためのAPI関数を提供します。:
 
 - グローバルマッピング:
@@ -923,6 +933,7 @@ Neovimはマッピングを設定、取得、削除するためのAPI関数を�
 3つ目の引数は、右側のマッピングを含む文字列(実行するコマンド)です。
 
 最後の引数は、[`:help :map-arguments`](https://neovim.io/doc/user/map.html#:map-arguments)で定義されているbool型のオプションのテーブルです(`noremap`を含み、`buffer`を除く)。
+Neovim 0.7.0から、マッピング実行時、右側のマッピングの代わりに `callback` オプションに渡した関数を呼び出せます。
 
 バッファローカルなマッピングは、バッファ番号を引数の最初に受け取ります(`0`を指定した場合、カレントバッファです)。
 
@@ -934,6 +945,15 @@ vim.api.nvim_set_keymap('n', '<Leader>tegf',  [[<Cmd>lua require('telescope.buil
 
 vim.api.nvim_buf_set_keymap(0, '', 'cc', 'line(".") == 1 ? "cc" : "ggcc"', { noremap = true, expr = true })
 -- :noremap <buffer> <expr> cc line('.') == 1 ? 'cc' : 'ggcc'
+
+vim.api.nvim_set_keymap('n', '<Leader>ex', '', {
+    noremap = true,
+    callback = function()
+        print('My example')
+    end,
+    -- Lua関数は便利な文字列表現を持っていないため、 "desc" オプションを使用してマッピングの説明を記入できます。
+    desc = 'Prints "My example" in the message area',
+})
 ```
 
 `vim.api.nvim_get_keymap()`は、モードの省略名(上記の表を参照)を含む文字列を受け取ります。
@@ -963,6 +983,78 @@ vim.api.nvim_del_keymap('n', '<Leader><Space>')
 ```lua
 vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
 -- :iunmap <buffer> <Tab>
+```
+
+### vim.keymap
+
+:警告: このセクションで説明するAPI関数はNeovim 0.7.0+のみで使用できます。
+
+Neovimはマッピングを設定/削除できる2つの関数を提供します:
+- [`vim.keymap.set()`](https://neovim.io/doc/user/lua.html#vim.keymap.set())
+- [`vim.keymap.del()`](https://neovim.io/doc/user/lua.html#vim.keymap.del())
+
+これらは、上記のAPI関数に糖類構文を追加したようなものです。
+
+`vim.keymap.set()` は最初の引数として文字列を受け取ります。
+また、複数のモードのマッピングを1度に定義するため、文字列のテーブルを受け取ることもできます:
+
+```lua
+vim.keymap.set('n', '<Leader>ex1', '<Cmd>lua vim.notify("Example 1")<CR>')
+vim.keymap.set({'n', 'c'}, '<Leader>ex2', '<Cmd>lua vim.notify("Example 2")<CR>')
+```
+
+2つ目の引数は左側のマッピングです。
+
+3つ目の引数は右側のマッピングで、文字列かLua関数を受け取れます。
+
+```lua
+vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>')
+vim.keymap.set('n', '<Leader>ex2', function() print("Example 2") end)
+vim.keymap.set('n', '<Leader>pl1', require('plugin').plugin_action)
+-- モジュールの読み込みによる起動コストを避けるため、マッピングを呼び出したときにモジュールの遅延読みこみができるように関数でラップすることができます。:
+vim.keymap.set('n', '<Leader>pl2', function() require('plugin').plugin_action() end)
+```
+
+4つ目の引数(省略可能)はオプションのテーブルで、 `vim.api.nvim_set_keymap()` に渡されるオプションに対応しており、いくつか追加項目があります([`:help vim.keymap.set()`](https://neovim.io/doc/user/lua.html#vim.keymap.set())に一覧があります)。
+
+```lua
+vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>', {buffer = true})
+vim.keymap.set('n', '<Leader>ex2', function() print('Example 2') end, {desc = 'Prints "Example 2" to the message area'})
+```
+
+このAPIが面白いところとして、Vimのマッピングの歴史的な癖をいくつか解消しています。
+- `rhs` が `<Plug>` マッピングである場合以外、デフォルトで `noremap` です。
+  このため、マッピングが再帰的であるかを考える必要はあまりないです。
+
+```lua
+vim.keymap.set('n', '<Leader>test1', '<Cmd>echo "test"<CR>')
+-- :nnoremap <Leader>test <Cmd>echo "test"<CR>
+
+-- マッピングを再帰的に行ないたい場合は、 `remap` オプションを `true` にします
+vim.keymap.set('n', '>', ']', {remap = true})
+-- :nmap > ]
+
+-- <Plug> マッピングは再帰的でないと機能しませんが、 vim.keymap.set() は自動的に処理します
+vim.keymap.set('n', '<Leader>plug', '<Plug>(plugin)')
+-- :nmap <Leader>plug <Plug>(plugin)
+```
+
+- `expr` マッピングが有効なら、 Lua関数が返す文字列に対して `nvim_replace_termcodes()` が自動的に適用されます:
+
+```lua
+vim.keymap.set('i', '<Tab>', function()
+    return vim.fn.pumvisible == 1 and '<C-N>' or '<Tab>'
+end, {expr = true})
+```
+
+参照:
+- [`:help recursive_mapping`](https://neovim.io/doc/user/map.html#recursive_mapping)
+
+`vim.keymap.del()` も同じように機能しますが、マッピングを削除します:
+
+```lua
+vim.keymap.del('n', '<Leader>ex1')
+vim.keymap.del({'n', 'c'}, '<Leader>ex2', {buffer = true})
 ```
 
 ## ユーザーコマンドを定義する

--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,30 @@ You can debug Lua code running in a separate Neovim instance with [jbyuki/one-sm
 
 The plugin uses the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/). Connecting to a debug adapter requires a DAP client like [mfussenegger/nvim-dap](https://github.com/mfussenegger/nvim-dap/) or [puremourning/vimspector](https://github.com/puremourning/vimspector/).
 
+### Debugging Lua mappings/commands/autocommands
+
+The `:verbose` command allows you to see where a mapping/command/autocommand was defined:
+
+```vim
+:verbose map m
+```
+
+```text
+n  m_          * <Cmd>echo 'example'<CR>
+        Last set from ~/.config/nvim/init.vim line 26
+```
+
+By default, this feature is disabled in Lua for performance reasons. You can enable it by starting Neovim with a verbose level greater than 0:
+
+```sh
+nvim -V1
+```
+
+See also:
+- [`:help 'verbose'`](https://neovim.io/doc/user/options.html#'verbose')
+- [`:help -V`](https://neovim.io/doc/user/starting.html#-V)
+- [neovim/neovim#15079](https://github.com/neovim/neovim/pull/15079)
+
 ### Testing Lua code
 
 - [plenary.nvim: test harness](https://github.com/nvim-lua/plenary.nvim/#plenarytest_harness)

--- a/doc/nvim-lua-guide.jax
+++ b/doc/nvim-lua-guide.jax
@@ -1204,12 +1204,12 @@ Neovimはユーザーコマンドを作成するAPI関数を提供します。
 <
 
 ==============================================================================
-autocommandを定義する
+オートコマンドを定義する
                                                 *luaguide-defining-autocommands*
 
 (この章は現在作成中です)
 
-Neovim 0.7.0はautocommands用のAPI関数を持っています。詳細は|api-autocmd|を参照してください。
+Neovim 0.7.0はオートコマンド用のAPI関数を持っています。詳細は|api-autocmd|を参照してください。
 
 - Pull request #14661: https://github.com/neovim/neovim/pull/14661 (lua: autocmds take 2)
 

--- a/doc/nvim-lua-guide.jax
+++ b/doc/nvim-lua-guide.jax
@@ -1389,6 +1389,31 @@ https://github.com/jbyuki/one-small-step-for-vimkind でデバッグできます
 デバッグアダプターに接続するには、 mfussenegger/nvim-dap: https://github.com/mfussenegger/nvim-dap/ や
 puremourning/vimspector: https://github.com/puremourning/vimspector/ のようなDAPクライアントが必要です。
 
+Luaマッピング/コマンド/オートコマンドのデバッグ~
+
+マッピング/コマンド/オートコマンドが定義されている位置を `:verbose` コマンドで確認できます:
+
+    >
+    :verbose map m
+<
+
+    >
+    n  m_          * <Cmd>echo 'example'<CR>
+            Last set from ~/.config/nvim/init.vim line 26
+<
+
+デフォルトでは、Luaのパフォーマンス上の理由でこの機能は無効です。
+Neovim起動時にverboseのレベルが0より上なら、この機能を有効にできます:
+
+    >
+    nvim -V1
+<
+
+参照:
+- |'verbose'|
+- |-V|
+-  neovim/neovim#15079: https://github.com/neovim/neovim/pull/15079
+
 Luaコードのテスト~
 
 -  plenary.nvim: test harness:

--- a/doc/nvim-lua-guide.jax
+++ b/doc/nvim-lua-guide.jax
@@ -422,7 +422,7 @@ scriptからLuaのグローバル名前空間(`_G`: https://www.lua.org/manual/5
     EOF
 
     inoremap <silent> <expr> <Tab>
-        \ pumvisible() ? "\<C-n>" :
+        \ pumvisible() ? "\<C-N>" :
         \ v:lua.check_back_space() ? "\<Tab>" :
         \ completion#trigger_completion()
 
@@ -621,7 +621,7 @@ vim.api.nvim_replace_termcodes()~
 次のようなマッピングを見たことがあるかもしれません。:
 
     >
-    inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+    inoremap <expr> <Tab> pumvisible() ? "\<C-N>" : "\<Tab>"
 <
 
 同じことをLuaでやると大変です。
@@ -629,14 +629,14 @@ vim.api.nvim_replace_termcodes()~
 
     >
     function _G.smart_tab()
-        return vim.fn.pumvisible() == 1 and [[\<C-n>]] or [[\<Tab>]]
+        return vim.fn.pumvisible() == 1 and [[\<C-N>]] or [[\<Tab>]]
     end
 
     vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr =
     true, noremap = true})
 <
 
-マッピングに `\<Tab>` と `\<C-n>` が挿入されているのを知るためだけに...
+マッピングに `\<Tab>` と `\<C-N>` が挿入されているのを知るためだけに...
 
 キーコードをエスケープできるのは、Vim scriptの機能です。
 `\r`, `\42` や `\x10` のような多くのプログラミング言語に共通する通常のエスケープシーケンスとは別に、
@@ -672,11 +672,20 @@ Luaにはそのような機能は組み込まれていません。
     end
 
     function _G.smart_tab()
-        return vim.fn.pumvisible() == 1 and t'<C-n>' or t'<Tab>'
+        return vim.fn.pumvisible() == 1 and t'<C-N>' or t'<Tab>'
     end
 
     vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr =
     true, noremap = true})
+<
+
+`vim.keymap.set()`では、このハックは必要ありません。
+`expr`が有効な場合、デフォルトで自動的に変換されます。:
+
+    >
+    vim.keymap.set('i', '<Tab>', function()
+        return vim.fn.pumvisible() == 1 and '<C-N>' or '<Tab>'
+    end, {expr = true})
 <
 
 参照:
@@ -993,6 +1002,8 @@ scriptでは`1`は真で`0`は偽になるため問題ありません。
 マッピングを定義する
                                                     *luaguide-defining-mappings*
 
+API関数~
+
 Neovimはマッピングを設定、取得、削除するためのAPI関数を提供します。:
 
 - グローバルマッピング:
@@ -1028,8 +1039,8 @@ Neovimはマッピングを設定、取得、削除するためのAPI関数を�
 
 3つ目の引数は、右側のマッピングを含む文字列(実行するコマンド)です。
 
-最後の引数は、`:help
-:map-arguments`で定義されているbool型のオプションのテーブルです(`noremap`を含み、`buffer`を除く)。
+最後の引数は、|:map-arguments| で定義されているbool型のオプションのテーブルです(`noremap`を含み、`buffer`を除く)。
+Neovim 0.7.0から、マッピング実行時、右側のマッピングの代わりに `callback` オプションに渡した関数を呼び出せます。
 
 バッファローカルなマッピングは、バッファ番号を引数の最初に受け取ります(`0`を指定した場合、カレントバッファです)。
 
@@ -1046,6 +1057,16 @@ Neovimはマッピングを設定、取得、削除するためのAPI関数を�
     vim.api.nvim_buf_set_keymap(0, '', 'cc', 'line(".") == 1 ? "cc" :
     "ggcc"', { noremap = true, expr = true })
     -- :noremap <buffer> <expr> cc line('.') == 1 ? 'cc' : 'ggcc'
+
+    vim.api.nvim_set_keymap('n', '<Leader>ex', '', {
+        noremap = true,
+        callback = function()
+            print('My example')
+        end,
+        -- Lua関数は便利な文字列表現を持っていないため、
+        -- "desc" オプションを使用してマッピングの説明を記入できます。
+        desc = 'Prints "My example" in the message area',
+    })
 <
 
 `vim.api.nvim_get_keymap()`は、モードの省略名(上記の表を参照)を含む文字列を受け取ります。
@@ -1075,6 +1096,89 @@ Neovimはマッピングを設定、取得、削除するためのAPI関数を�
     >
     vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
     -- :iunmap <buffer> <Tab>
+<
+
+vim.keymap~
+
+:警告: このセクションで説明するAPI関数はNeovim
+0.7.0+のみで使用できます。
+
+Neovimはマッピングを設定/削除できる2つの関数を提供します:
+- |vim.keymap.set()|
+- |vim.keymap.del()|
+
+これらは、上記の類似API関数に糖類構文を追加したようなものです。
+
+`vim.keymap.set()`
+は最初の引数として文字列を受け取ります。
+また、複数のモードのマッピングを1度に定義するため、文字列のテーブルを受け取ることもできます:
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>lua vim.notify("Example
+    1")<CR>')
+    vim.keymap.set({'n', 'c'}, '<Leader>ex2', '<Cmd>lua
+    vim.notify("Example 2")<CR>')
+<
+
+2つ目の引数は左側のマッピングです。
+
+3つ目の引数は右側のマッピングで、文字列かLua関数を受け取れます。
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>')
+    vim.keymap.set('n', '<Leader>ex2', function() print("Example 2") end)
+    vim.keymap.set('n', '<Leader>pl1', require('plugin').plugin_action)
+    -- モジュールの読み込みによる起動コストを避けるため、
+    -- マッピングを呼び出したときにモジュールの遅延読みこみができるように関数でラップすることができます。:
+    vim.keymap.set('n', '<Leader>pl2', function() require('plugin').plugin_action() end)
+<
+
+4つ目の引数)省略可能)はオプションのテーブルで、 `vim.api.nvim_set_keymap`
+に渡されるオプションに対応しており、いくつか追加項目があります
+(|vim.keymap.set()|にhttps://neovim.io/doc/user/lua.html#vim.keymap.setに一覧があります)。
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>',
+    {buffer = true})
+    vim.keymap.set('n', '<Leader>ex2', function() print('Example 2')
+    end, {desc = 'Prints "Example 2" to the message area'})
+<
+
+このAPIが面白いところとして、Vimのマッピングの歴史的な癖をいくつか解消しています。
+- `rhs` が `<Plug>` マッピングである場合以外、デフォルトで `noremap` です。
+  このため、マッピングが再帰的であるかを考える必要はあまりないです。
+
+    >
+    vim.keymap.set('n', '<Leader>test1', '<Cmd>echo "test"<CR>')
+    -- :nnoremap <Leader>test <Cmd>echo "test"<CR>
+
+    -- マッピングを再帰的に行ないたい場合は、 `remap`
+    オプションを `true` にします
+    vim.keymap.set('n', '>', ']', {remap = true})
+    -- :nmap > ]
+
+    -- <Plug> マッピングは再帰的でないと機能しませんが、 vim.keymap.set() は自動的に処理します
+    vim.keymap.set('n', '<Leader>plug', '<Plug>(plugin)')
+    -- :nmap <Leader>plug <Plug>(plugin)
+<
+
+- `expr` マッピングが有効なら、 Lua関数が返す文字列に対して `nvim_replace_termcodes()` が自動的に適用されます:
+
+    >
+    vim.keymap.set('i', '<Tab>', function()
+        return vim.fn.pumvisible == 1 and '<C-N>' or '<Tab>'
+    end, {expr = true})
+<
+
+参照:
+-  `:help recursive_mapping`:
+https://neovim.io/doc/user/map.html#recursive_mapping
+
+`vim.keymap.del()` も同じように機能しますが、マッピングを削除します:
+
+    >
+    vim.keymap.del('n', '<Leader>ex1')
+    vim.keymap.del({'n', 'c'}, '<Leader>ex2', {buffer = true})
 <
 
 ==============================================================================

--- a/doc/nvim-lua-guide.txt
+++ b/doc/nvim-lua-guide.txt
@@ -1489,6 +1489,32 @@ a debug adapter requires a DAP client like  mfussenegger/nvim-dap:
 https://github.com/mfussenegger/nvim-dap/  or  puremourning/vimspector:
 https://github.com/puremourning/vimspector/ .
 
+Debugging Lua mappings/commands/autocommands~
+
+The `:verbose` command allows you to see where a
+mapping/command/autocommand was defined:
+
+    >
+    :verbose map m
+<
+
+    >
+    n  m_          * <Cmd>echo 'example'<CR>
+            Last set from ~/.config/nvim/init.vim line 26
+<
+
+By default, this feature is disabled in Lua for performance reasons. You
+can enable it by starting Neovim with a verbose level greater than 0:
+
+    >
+    nvim -V1
+<
+
+See also:
+- |'verbose'|
+- |-V|
+-  neovim/neovim#15079: https://github.com/neovim/neovim/pull/15079
+
 Testing Lua code~
 
 -  plenary.nvim: test harness:

--- a/doc/nvim-lua-guide.txt
+++ b/doc/nvim-lua-guide.txt
@@ -438,7 +438,7 @@ types and vice versa.
     EOF
 
     inoremap <silent> <expr> <Tab>
-        \ pumvisible() ? "\<C-n>" :
+        \ pumvisible() ? "\<C-N>" :
         \ v:lua.check_back_space() ? "\<Tab>" :
         \ completion#trigger_completion()
 
@@ -651,7 +651,7 @@ This API function allows you to escape terminal codes and Vim keycodes.
 You may have come across mappings like this one:
 
     >
-    inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+    inoremap <expr> <Tab> pumvisible() ? "\<C-N>" : "\<Tab>"
 <
 
 Trying to do the same in Lua can prove to be a challenge. You might be
@@ -659,14 +659,14 @@ tempted to do it like this:
 
     >
     function _G.smart_tab()
-        return vim.fn.pumvisible() == 1 and [[\<C-n>]] or [[\<Tab>]]
+        return vim.fn.pumvisible() == 1 and [[\<C-N>]] or [[\<Tab>]]
     end
 
     vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr =
     true, noremap = true})
 <
 
-only to find out that the mapping inserts `\<Tab>` and `\<C-n>`
+only to find out that the mapping inserts `\<Tab>` and `\<C-N>`
 literally...
 
 Being able to escape keycodes is actually a Vimscript feature. Aside
@@ -704,11 +704,21 @@ Coming back to our earlier example, this should now work as expected:
     end
 
     function _G.smart_tab()
-        return vim.fn.pumvisible() == 1 and t'<C-n>' or t'<Tab>'
+        return vim.fn.pumvisible() == 1 and t'<C-N>' or t'<Tab>'
     end
 
     vim.api.nvim_set_keymap('i', '<Tab>', 'v:lua.smart_tab()', {expr =
     true, noremap = true})
+<
+
+This is not necessary with `vim.keymap.set()` as it automatically
+transforms vim keycodes returned by Lua functions in `expr` mappings
+by default:
+
+    >
+    vim.keymap.set('i', '<Tab>', function()
+        return vim.fn.pumvisible() == 1 and '<C-N>' or '<Tab>'
+    end, {expr = true})
 <
 
 See also:
@@ -1049,6 +1059,8 @@ check for `1` or `0`:
 DEFINING MAPPINGS
                                                     *luaguide-defining-mappings*
 
+API functions~
+
 Neovim provides a list of API functions to set, get and delete mappings:
 
 - Global mappings:
@@ -1088,7 +1100,9 @@ The third argument is a string containing the right-hand side of the
 mapping (the command to execute).
 
 The final argument is a table containing boolean options for the mapping
-as defined in |:map-arguments|.
+as defined in |:map-arguments|. Since Neovim 0.7.0, you can also pass a
+`callback` option to invoke a Lua function instead of the right-hand
+side when executing the mapping.
 
 Buffer-local mappings also take a buffer number as their first argument
 (`0` sets the mapping for the current buffer).
@@ -1106,6 +1120,16 @@ Buffer-local mappings also take a buffer number as their first argument
     vim.api.nvim_buf_set_keymap(0, '', 'cc', 'line(".") == 1 ? "cc" :
     "ggcc"', { noremap = true, expr = true })
     -- :noremap <buffer> <expr> cc line('.') == 1 ? 'cc' : 'ggcc'
+
+    vim.api.nvim_set_keymap('n', '<Leader>ex', '', {
+        noremap = true,
+        callback = function()
+            print('My example')
+        end,
+        -- Since Lua function don't have a useful string representation,
+        you can use the "desc" option to document your mapping
+        desc = 'Prints "My example" in the message area',
+    })
 <
 
 `vim.api.nvim_get_keymap()` takes a string containing the shortname of
@@ -1139,6 +1163,90 @@ first argument, with `0` representing the current buffer.
     >
     vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
     -- :iunmap <buffer> <Tab>
+<
+
+vim.keymap~
+
+WARNING: The functions discussed in this section are only available in
+Neovim 0.7.0+
+
+Neovim provides two functions to set/del mappings:
+- |vim.keymap.set()|
+- |vim.keymap.del()|
+
+These are similar to the above API functions with added syntactic sugar.
+
+`vim.keymap.set()` takes a string as its first argument. It can also be
+a table of strings to define mappings for multiple modes at once:
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>lua vim.notify("Example
+    1")<CR>')
+    vim.keymap.set({'n', 'c'}, '<Leader>ex2', '<Cmd>lua
+    vim.notify("Example 2")<CR>')
+<
+
+The second argument is the left-hand side of the mapping.
+
+The third argument is the right-hand side of the mapping, which can
+either be a string or a Lua function:
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>')
+    vim.keymap.set('n', '<Leader>ex2', function() print("Example 2") end)
+    vim.keymap.set('n', '<Leader>pl1', require('plugin').plugin_action)
+    -- To avoid the startup cost of requiring the module, you can wrap
+    it in a function to require it lazily when invoking the mapping:
+    vim.keymap.set('n', '<Leader>pl2', function()
+    require('plugin').plugin_action() end)
+<
+
+The fourth (optional) argument is a table of options that correspond to
+the options passed to `vim.api.nvim_set_keymap()`, with a few additions
+(see |vim.keymap.set()|.
+
+    >
+    vim.keymap.set('n', '<Leader>ex1', '<Cmd>echomsg "Example 1"<CR>',
+    {buffer = true})
+    vim.keymap.set('n', '<Leader>ex2', function() print('Example 2')
+    end, {desc = 'Prints "Example 2" to the message area'})
+<
+
+An interesting feature of this API is that it irons out some historical
+quirks of Vim mappings:
+- Mappings are `noremap` by default, except when the `rhs` is a `<Plug>`
+mapping. This means you rarely have to think about whether a mapping
+should be recursive or not:
+    ```lua
+    vim.keymap.set('n', '<Leader>test1', '<Cmd>echo "test"<CR>')
+    -- :nnoremap <Leader>test <Cmd>echo "test"<CR>
+
+    -- If you DO want the mapping to be recursive, set the "remap"
+    option to "true"
+    vim.keymap.set('n', '>', ']', {remap = true})
+    -- :nmap > ]
+
+    -- <Plug> mappings don't work unless they're recursive,
+    vim.keymap.set() handles that for you automatically
+    vim.keymap.set('n', '<Leader>plug', '<Plug>(plugin)')
+    -- :nmap <Leader>plug <Plug>(plugin)
+    ```
+- In `expr` mappings, `nvim_replace_termcodes()` is automatically applied
+to strings returned from Lua functions:
+    ```lua
+    vim.keymap.set('i', '<Tab>', function()
+        return vim.fn.pumvisible == 1 and '<C-N>' or '<Tab>'
+    end, {expr = true})
+    ```
+
+See also:
+- |recursive_mapping|
+
+`vim.keymap.del()` works the same way but deletes mappings instead:
+
+    >
+    vim.keymap.del('n', '<Leader>ex1')
+    vim.keymap.del({'n', 'c'}, '<Leader>ex2', {buffer = true})
 <
 
 ==============================================================================


### PR DESCRIPTION
25d4602bf16d61337e72b90bac8609352c5f93f5 まで和訳しました。